### PR TITLE
Build with PlatformIO instead of Arduino IDE

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,29 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = m5stack-core-esp32
+src_dir = networktester
+
+[env:m5stack-core-esp32]
+platform = espressif32
+framework = arduino
+board = m5stack-core-esp32
+
+build_flags = -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS -D CFG_eu868 -D CFG_sx1276_radio
+
+lib_deps =
+  m5stack/M5Stack
+  https://github.com/Bjoerns-TB/M5_UI.git#TTN-Mapper-Colours-Progressbar
+  https://github.com/Bjoerns-TB/arduino-lmic.git#LMIC_setLinkCheckRequestOnce
+  makuna/NeoPixelBus
+  mikalhart/TinyGPSPlus
+
+upload_port = /dev/ttyUSB*


### PR DESCRIPTION
I've added a platformio.ini to build the project using PlatformIO instead of the Arduino IDE.

PlatformIO will automate the whole build process including the download of the toolchain and all required libraries. It is not necessary to patch the lmic_project_config.h as the flags are included in the ini file.
